### PR TITLE
remove EOS.undent call

### DIFF
--- a/Formula/ardour5.rb
+++ b/Formula/ardour5.rb
@@ -50,7 +50,7 @@ class Ardour5 < Formula
       system "git", "tag", "-a", "-m", "head tag", "5.10"
     end
 
-    (buildpath/"libs/ardour/revision.cc").write <<-EOS.undent
+    (buildpath/"libs/ardour/revision.cc").write <<-EOS
       #include "ardour/revision.h"
       namespace ARDOUR { const char* revision = "5.10-999"; }
     EOS


### PR DESCRIPTION
this solves the EOS.undent failure when installing ardour5:

```➜ brew install ardour5
==> Installing ardour5 from david0/audio
/usr/bin/sandbox-exec -f /tmp/homebrew20180516-6950-1nwzshf.sb nice /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3_2/bin/ruby -W0 -I /usr/local/Homebrew/Library/Homebrew -- /usr/local/Homebrew/Library/Homebrew/build.rb /usr/local/Homebrew/Library/Taps/david0/homebrew-audio/Formula/ardour5.rb --verbose
==> Cloning git://git.ardour.org/ardour/ardour.git
Updating /Users/genevera/Library/Caches/Homebrew/ardour5--git
git config remote.origin.url git://git.ardour.org/ardour/ardour.git
git config remote.origin.fetch +refs/tags/5.10:refs/tags/5.10
==> Checking out tag 5.10
git checkout -f 5.10 --
HEAD is now at 9c629c0 Fix region-gain offset when separating ranges
git reset --hard 5.10
HEAD is now at 9c629c0 Fix region-gain offset when separating ranges
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/david0/homebrew-audio/Formula/ardour5.rb:56:in `install'
Please report this to the david0/audio tap!
Or, even better, submit a PR to fix it!
4.63s user 2.04s system 90% cpu 7.396s total
```