### PR TITLE
comment out depends_on x11

### DIFF
--- a/Formula/ardour5.rb
+++ b/Formula/ardour5.rb
@@ -28,7 +28,7 @@ class Ardour5 < Formula
   depends_on "fftw"
   depends_on "lilv"
   depends_on "libsigc++"
-  depends_on :x11 => :optional
+#  depends_on :x11 => :optional
 
   depends_on "python3" => :build # for fix-installnames-magic
 


### PR DESCRIPTION
This gets the tap installing again:

```shell
% brew tap genevera/audio
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 4 formulae.

Updating Homebrew...
==> Tapping genevera/audio
Cloning into '/opt/homebrew/Library/Taps/genevera/homebrew-audio'...
remote: Enumerating objects: 35, done.
remote: Counting objects: 100% (35/35), done.
remote: Compressing objects: 100% (27/27), done.
remote: Total 265 (delta 9), reused 29 (delta 8), pack-reused 230
Receiving objects: 100% (265/265), 50.76 KiB | 2.54 MiB/s, done.
Resolving deltas: 100% (96/96), done.
Tapped 21 formulae (49 files, 127.6KB).
```